### PR TITLE
fix: correctly recognize NoData values in metadata

### DIFF
--- a/scripts/translate2.sh
+++ b/scripts/translate2.sh
@@ -151,7 +151,7 @@ else
   rc=$?
   if [ $rc -ne 0 ]; then
     # No ALPHA found -> try to convert NODATA to ALPHA
-    warp_args="$warp_args -dstalpha"
+    warp_args="$warp_args -wo \"UNIFIED_SRC_NODATA=YES\" -dstalpha"
   else
     # ALPHA found -> do nothing
     echo "File already has Alpha channel"


### PR DESCRIPTION
Without the new setting that was added at least in some cases where the
images is a Tiff the NoData values were not correctly detected when
converting them to an alpha channel.

ING-1903

I verified this in https://github.com/wetransform/testbed-deegree-raster with the test data from WGS-423.