### PR TITLE
feat: special case handling for GeoTiff w/ single Grayscale band

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DATA_DIR /opt/data
 
 # Install needed utilities and setup folders
 RUN apt-get update -y && \
-  apt-get install -y zip unzip curl && \
+  apt-get install -y zip unzip curl jq && \
   apt-get autoremove -y && \
   apt-get clean && \
   mkdir -p /opt/convert && \


### PR DESCRIPTION
Adds pre-processing in case a file w/ one or two bands is detected,
where the first band is a Grayscale band. If the second band exists it
is assumed to be the Alpha band. Otherwise the pre-processing tries to
create an Alpha band. Afterwards the image is converted to an RGBA
image.

ING-2008